### PR TITLE
Fixing background to avoid duplicate listening

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -19,7 +19,7 @@ const session: RecordedSession = {
   sender: null,
 };
 
-let port: chrome.runtime.Port;
+let port: chrome.runtime.Port | null = null;
 
 /**
  * Handles events sent from the event recorder.
@@ -56,7 +56,7 @@ function injectEventRecorder(): void {
  * Disconnects the event recorder.
  */
 function ejectEventRecorder(): void {
-  port.disconnect();
+  if (port) port.disconnect();
 }
 
 /**
@@ -89,6 +89,7 @@ function stopRecording(sendResponse: (response: BlockData) => void): void {
 function resetRecording(): void {
   session.events = [];
   session.sender = null;
+  chrome.storage.local.set({ codeBlocks: [] });
 }
 
 /**
@@ -122,8 +123,10 @@ function handleControlAction(
  * Performs necessary cleanup on startup and suspend.
  */
 function cleanUp(): void {
+  console.log('cleanup');
+  ejectEventRecorder();
+  resetRecording();
   chrome.storage.local.set({ status: 'off' });
-  chrome.storage.local.set({ codeBlocks: [] });
 }
 
 /**

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -80,16 +80,17 @@ function stopRecording(sendResponse: (response: BlockData) => void): void {
   const code = generateCode(session);
   sendResponse(code);
   chrome.storage.local.set({ codeBlocks: code });
-  resetRecording();
+  session.events = [];
+  session.sender = null;
 }
 
 /**
- * Resets the recording process.
+ * Performs necessary cleanup on startup and suspend.
  */
-function resetRecording(): void {
-  session.events = [];
-  session.sender = null;
+function cleanUp(): void {
+  ejectEventRecorder();
   chrome.storage.local.set({ codeBlocks: [] });
+  chrome.storage.local.set({ status: 'off' });
 }
 
 /**
@@ -112,21 +113,11 @@ function handleControlAction(
       stopRecording(sendResponse);
       break;
     case 'resetRec':
-      resetRecording();
+      cleanUp();
       break;
     default:
       throw new Error('Invalid action type');
   }
-}
-
-/**
- * Performs necessary cleanup on startup and suspend.
- */
-function cleanUp(): void {
-  console.log('cleanup');
-  ejectEventRecorder();
-  resetRecording();
-  chrome.storage.local.set({ status: 'off' });
 }
 
 /**

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -82,6 +82,7 @@ function stopRecording(sendResponse: (response: BlockData) => void): void {
   chrome.storage.local.set({ codeBlocks: code });
   session.events = [];
   session.sender = null;
+  port = null;
 }
 
 /**


### PR DESCRIPTION
Background now saves only the sender of the first eventRecorder in a single session.
Reshuffled flow to avoid duplicate event listening.