### PR TITLE
Button "grayed out" on invalid tabs (color scheme TBD)

### DIFF
--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -88,18 +88,6 @@ body {
   padding: 20;
 }
 
-#disabled-button {
-  background-color: rgb(106, 174, 143);
-  border: 1px solid rgb(248, 249, 250);
-  margin: 10px;
-  padding: 15px;
-  border-radius: 4px;
-  font-size: 16px;
-  font-weight: 400;
-  color: rgb(248, 249, 250);
-  line-height: 8px;
-}
-
 /**
  * Classes.
  */
@@ -120,6 +108,18 @@ body {
     color: rgb(49, 158, 107);
     transition: all 0.15s ease 0s;
   }
+}
+
+.disabled-button {
+  background-color: rgb(106, 174, 143);
+  border: 1px solid rgb(248, 249, 250);
+  margin: 10px;
+  padding: 15px;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 400;
+  color: rgb(248, 249, 250);
+  line-height: 8px;
 }
 
 .text {

--- a/src/assets/styles/styles.scss
+++ b/src/assets/styles/styles.scss
@@ -88,6 +88,18 @@ body {
   padding: 20;
 }
 
+#disabled-button {
+  background-color: rgb(106, 174, 143);
+  border: 1px solid rgb(248, 249, 250);
+  margin: 10px;
+  padding: 15px;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 400;
+  color: rgb(248, 249, 250);
+  line-height: 8px;
+}
+
 /**
  * Classes.
  */

--- a/src/popup/components/ToggleButton.tsx
+++ b/src/popup/components/ToggleButton.tsx
@@ -18,7 +18,7 @@ export default ({ recStatus, handleToggle, isValidTab }: ToggleButtonProps) => {
 
   return (
     <>
-      <button type="button" className="button" onClick={handleClick} disabled={!isValidTab && recStatus === 'off'}>
+      <button type="button" className="button" id={!isValidTab && recStatus === 'off' && 'disabled-button'} onClick={handleClick} disabled={!isValidTab && recStatus === 'off'}>
         {recStatus === 'off' && !isValidTab && 'Invalid Tab'}
         {recStatus === 'off' && isValidTab && 'Start Recording'}
         {recStatus === 'on' && 'Stop Recording'}

--- a/src/popup/components/ToggleButton.tsx
+++ b/src/popup/components/ToggleButton.tsx
@@ -16,9 +16,11 @@ export default ({ recStatus, handleToggle, isValidTab }: ToggleButtonProps) => {
     handleToggle(action);
   };
 
+  const buttonClass: string = (!isValidTab && recStatus === 'off') ? 'disabled-button' : 'button';
+
   return (
     <>
-      <button type="button" className="button" id={!isValidTab && recStatus === 'off' && 'disabled-button'} onClick={handleClick} disabled={!isValidTab && recStatus === 'off'}>
+      <button type="button" className={buttonClass} onClick={handleClick} disabled={!isValidTab && recStatus === 'off'}>
         {recStatus === 'off' && !isValidTab && 'Invalid Tab'}
         {recStatus === 'off' && isValidTab && 'Start Recording'}
         {recStatus === 'on' && 'Stop Recording'}


### PR DESCRIPTION
Button "grayed out" on invalid tabs. We currently have it as a light green matching the lighter green in our logo. We may change this to a different color/combination in the future to more effectively and aesthetically convey the disabled status of the button.