### PR TITLE
1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-recorder",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3066,21 +3066,13 @@
       }
     },
     "css-tree": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
+      "version": "1.0.0-alpha.37",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
       "dev": true,
       "requires": {
         "mdn-data": "2.0.4",
-        "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
+        "source-map": "^0.6.1"
       }
     },
     "css-unit-converter": {
@@ -3178,34 +3170,28 @@
       "dev": true
     },
     "csso": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-3.5.1.tgz",
-      "integrity": "sha512-vrqULLffYU1Q2tLdJvaCYbONStnfkfimRxXNaGjxMldI0C7JPBC4rB1RyjhfdZ4m1frm8pM9uRPKH3d2knZ8gg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
+      "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
       "dev": true,
       "requires": {
-        "css-tree": "1.0.0-alpha.29"
+        "css-tree": "1.0.0-alpha.39"
       },
       "dependencies": {
         "css-tree": {
-          "version": "1.0.0-alpha.29",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.29.tgz",
-          "integrity": "sha512-sRNb1XydwkW9IOci6iB2xmy8IGCj6r/fr+JWitvJ2JxQRPzN3T4AGGVWCMlVmVwM1gtgALJRmGIlWv5ppnGGkg==",
+          "version": "1.0.0-alpha.39",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
+          "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
           "dev": true,
           "requires": {
-            "mdn-data": "~1.1.0",
-            "source-map": "^0.5.3"
+            "mdn-data": "2.0.6",
+            "source-map": "^0.6.1"
           }
         },
         "mdn-data": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-          "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
+          "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==",
           "dev": true
         }
       }
@@ -4568,14 +4554,13 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.12.1",
-        "node-pre-gyp": "^0.12.0"
+        "node-pre-gyp": "*"
       },
       "dependencies": {
         "abbrev": {
@@ -4623,7 +4608,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4653,7 +4638,7 @@
           "optional": true
         },
         "debug": {
-          "version": "4.1.1",
+          "version": "3.2.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4680,12 +4665,12 @@
           "optional": true
         },
         "fs-minipass": {
-          "version": "1.2.5",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -4711,7 +4696,7 @@
           }
         },
         "glob": {
-          "version": "7.1.3",
+          "version": "7.1.6",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4740,7 +4725,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4759,7 +4744,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4795,13 +4780,13 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4811,42 +4796,42 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
-          "version": "2.1.1",
+          "version": "2.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
-          "version": "2.3.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^4.1.0",
+            "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
           }
         },
         "node-pre-gyp": {
-          "version": "0.12.0",
+          "version": "0.14.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4860,11 +4845,11 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4874,19 +4859,29 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.6",
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "npm-normalize-package-bin": "^1.0.1"
+          }
+        },
+        "npm-normalize-package-bin": {
+          "version": "1.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -4951,7 +4946,7 @@
           "optional": true
         },
         "process-nextick-args": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4966,18 +4961,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4992,7 +4979,7 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -5019,7 +5006,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5072,18 +5059,18 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.8",
+          "version": "4.4.13",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
+            "minipass": "^2.8.6",
+            "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
+            "yallist": "^3.0.3"
           }
         },
         "util-deprecate": {
@@ -5108,7 +5095,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -5416,25 +5403,35 @@
       "dev": true
     },
     "htmlnano": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.4.tgz",
-      "integrity": "sha512-wsg7+Hjyi1gHpMUixkeOjeRUNhBBTnEDB//kzvVHR+LUK4p+/31DAyE+pEACT0SQk3W0KE7Xdylk9+uNxdHXLg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-0.2.5.tgz",
+      "integrity": "sha512-X1iPSwXG/iF9bVs+/obt2n6F64uH0ETkA8zp7qFDmLW9/+A6ueHGeb/+qD67T21qUY22owZPMdawljN50ajkqA==",
       "dev": true,
       "requires": {
         "cssnano": "^4.1.10",
         "normalize-html-whitespace": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "posthtml": "^0.11.4",
+        "posthtml": "^0.12.0",
         "posthtml-render": "^1.1.5",
-        "svgo": "^1.2.2",
-        "terser": "^4.1.2",
-        "uncss": "^0.17.0"
+        "purgecss": "^1.4.0",
+        "svgo": "^1.3.2",
+        "terser": "^4.3.9",
+        "uncss": "^0.17.2"
       },
       "dependencies": {
+        "posthtml": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.12.0.tgz",
+          "integrity": "sha512-aNUEP/SfKUXAt+ghG51LC5MmafChBZeslVe/SSdfKIgLGUVRE68mrMF4V8XbH07ZifM91tCSuxY3eHIFLlecQw==",
+          "dev": true,
+          "requires": {
+            "posthtml-parser": "^0.4.1",
+            "posthtml-render": "^1.1.5"
+          }
+        },
         "terser": {
-          "version": "4.3.9",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-4.3.9.tgz",
-          "integrity": "sha512-NFGMpHjlzmyOtPL+fDw3G7+6Ueh/sz4mkaUYa4lJCxOPTNzd0Uj0aZJOmsDYoSQyfuVoWDMSWTPU3huyOm2zdA==",
+          "version": "4.6.10",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.10.tgz",
+          "integrity": "sha512-qbF/3UOo11Hggsbsqm2hPa6+L4w7bkr+09FNseEe8xrcVD3APGLFqE+Oz1ZKAxjYnFsj80rLOfgAtJ0LNJjtTA==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -6989,9 +6986,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {
@@ -7016,12 +7013,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "moo": {
@@ -7041,13 +7038,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "dev": true,
-      "optional": true
     },
     "nanoid": {
       "version": "2.1.6",
@@ -8425,6 +8415,120 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "purgecss": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-1.4.2.tgz",
+      "integrity": "sha512-hkOreFTgiyMHMmC2BxzdIw5DuC6kxAbP/gGOGd3MEsF3+5m69rIvUEPaxrnoUtfODTFKe9hcXjGwC6jcjoyhOw==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^6.0.0",
+        "yargs": "^14.0.0"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+          "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "postcss-selector-parser": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+          "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+          "dev": true,
+          "requires": {
+            "cssesc": "^3.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -9824,17 +9928,17 @@
       }
     },
     "svgo": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
-      "integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
+      "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "coa": "^2.0.2",
         "css-select": "^2.0.0",
         "css-select-base-adapter": "^0.1.1",
-        "css-tree": "1.0.0-alpha.33",
-        "csso": "^3.5.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
         "js-yaml": "^3.13.1",
         "mkdirp": "~0.5.1",
         "object.values": "^1.1.0",
@@ -9845,16 +9949,22 @@
       },
       "dependencies": {
         "css-select": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
-          "integrity": "sha512-dSpYaDVoWaELjvZ3mS6IKZM/y2PMPa/XYoEfYNZePL4U/XgyxZNroHEHReDx/d+VgXh9VbCTtFqLkFbmeqeaRQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
+          "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
           "dev": true,
           "requires": {
             "boolbase": "^1.0.0",
-            "css-what": "^2.1.2",
+            "css-what": "^3.2.1",
             "domutils": "^1.7.0",
             "nth-check": "^1.0.2"
           }
+        },
+        "css-what": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
+          "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
+          "dev": true
         },
         "domutils": {
           "version": "1.7.0",
@@ -10299,9 +10409,9 @@
       "dev": true
     },
     "uncss": {
-      "version": "0.17.2",
-      "resolved": "https://registry.npmjs.org/uncss/-/uncss-0.17.2.tgz",
-      "integrity": "sha512-hu2HquwDItuGDem4YsJROdAD8SknmWtM24zwhQax6J1se8tPjV1cnwPKhtjodzBaUhaL8Zb3hlGdZ2WAUpbAOg==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/uncss/-/uncss-0.17.3.tgz",
+      "integrity": "sha512-ksdDWl81YWvF/X14fOSw4iu8tESDHFIeyKIeDrK6GEVTQvqJc1WlOEXqostNwOCi3qAj++4EaLsdAgPmUbEyog==",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-recorder",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Records a user session and generates cypress code for automation and testing purposes.",
   "main": "index.js",
   "scripts": {

--- a/src/__tests__/Body.test.tsx
+++ b/src/__tests__/Body.test.tsx
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import Body, { BodyProps } from '../popup/components/Body';
 import LandingBox from '../popup/components/LandingBox';
 import CodeDisplay from '../popup/components/CodeDisplay';
+import { RecState } from '../constants';
 import '../setupTests';
 
 describe('Body', () => {
@@ -14,7 +15,7 @@ describe('Body', () => {
       isValidTab: true,
       destroyBlock: jest.fn(),
       moveBlock: jest.fn(),
-      recStatus: 'off',
+      recStatus: RecState.OFF,
     };
   });
   it('Should render LandingBox when recStatus is off', () => {
@@ -24,13 +25,13 @@ describe('Body', () => {
     expect(wrapper.exists(CodeDisplay)).toBe(false);
   });
   it('Should render CodeDisplay when recStatus is paused', () => {
-    props.recStatus = 'paused';
+    props.recStatus = RecState.PAUSED;
     wrapper = shallow(<Body {...props} />);
     expect(wrapper.exists(CodeDisplay)).toBe(true);
     expect(wrapper.exists(LandingBox)).toBe(false);
   });
   it('Should render CodeDisplay when recStatus is on', () => {
-    props.recStatus = 'on';
+    props.recStatus = RecState.ON;
     wrapper = shallow(<Body {...props} />);
     expect(wrapper.exists(CodeDisplay)).toBe(true);
     expect(wrapper.exists(LandingBox)).toBe(false);

--- a/src/__tests__/ToggleButton.test.tsx
+++ b/src/__tests__/ToggleButton.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { shallow } from 'enzyme';
 import ToggleButton from '../popup/components/ToggleButton';
-import { ControlAction } from '../constants';
+import { ControlAction, RecState } from '../constants';
 import '../setupTests';
 
 describe('toggle button', () => {
@@ -11,28 +11,28 @@ describe('toggle button', () => {
     handleToggleMock = jest.fn();
   });
   it('should not call handletoggle when clicked and recStatus is "off" and tab is invalid', () => {
-    wrapper = shallow(<ToggleButton recStatus="off" isValidTab={false} handleToggle={handleToggleMock} />);
+    wrapper = shallow(<ToggleButton recStatus={RecState.OFF} isValidTab={false} handleToggle={handleToggleMock} />);
     expect(wrapper).toMatchSnapshot();
     const button = wrapper.find('button');
     expect(button.text()).toBe('Invalid Tab');
     expect(button.prop('disabled')).toBe(true);
   });
   it('should call handletoggle with argument "startRec" when clicked and recStatus is "off" and tab is valid', () => {
-    wrapper = shallow(<ToggleButton recStatus="off" isValidTab handleToggle={handleToggleMock} />);
+    wrapper = shallow(<ToggleButton recStatus={RecState.OFF} isValidTab handleToggle={handleToggleMock} />);
     expect(wrapper).toMatchSnapshot();
     const button = wrapper.find('button');
     button.simulate('click');
     expect(handleToggleMock).toHaveBeenCalledWith(ControlAction.START);
   });
   it('should call handletoggle with argument "stopRec" when clicked and recStatus is "on"', () => {
-    wrapper = shallow(<ToggleButton recStatus="on" isValidTab handleToggle={handleToggleMock} />);
+    wrapper = shallow(<ToggleButton recStatus={RecState.ON} isValidTab handleToggle={handleToggleMock} />);
     expect(wrapper).toMatchSnapshot();
     const button = wrapper.find('button');
     button.simulate('click');
     expect(handleToggleMock).toHaveBeenCalledWith(ControlAction.STOP);
   });
   it('should call handletoggle with argument "startRec" when clicked and recStatus is "paused"', () => {
-    wrapper = shallow(<ToggleButton recStatus="paused" isValidTab handleToggle={handleToggleMock} />);
+    wrapper = shallow(<ToggleButton recStatus={RecState.PAUSED} isValidTab handleToggle={handleToggleMock} />);
     expect(wrapper).toMatchSnapshot();
     const button = wrapper.find('button');
     button.simulate('click');

--- a/src/__tests__/__snapshots__/App.test.tsx.snap
+++ b/src/__tests__/__snapshots__/App.test.tsx.snap
@@ -13,13 +13,13 @@ exports[`App Should match snapshot, render Header, Body, and Footer 1`] = `
     destroyBlock={[Function]}
     isValidTab={true}
     moveBlock={[Function]}
-    recStatus="off"
+    recStatus={1}
   />
   <Component
     copyToClipboard={[Function]}
     handleToggle={[Function]}
     isValidTab={true}
-    recStatus="off"
+    recStatus={1}
   />
 </div>
 `;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -14,3 +14,9 @@ export enum ControlAction {
   MOVE,
   PUSH,
 }
+
+export enum RecState {
+  ON,
+  OFF,
+  PAUSED,
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,10 +7,10 @@ export enum EventType {
 }
 
 export enum ControlAction {
-  START = 'startRec',
-  STOP = 'stopRec',
-  RESET = 'resetRec',
-  DELETE = 'deleteBlock',
-  MOVE = 'moveBlock',
-  PUSH = 'pushBlock',
+  START,
+  STOP,
+  RESET,
+  DELETE,
+  MOVE,
+  PUSH,
 }

--- a/src/helpers/model.ts
+++ b/src/helpers/model.ts
@@ -1,5 +1,6 @@
 import { generate } from 'shortid';
-import { RecState, Block } from '../types';
+import { Block } from '../types';
+import { RecState } from '../constants';
 
 export default class Model {
   status: RecState;
@@ -20,10 +21,10 @@ export default class Model {
         if (chrome.runtime.lastError) reject(chrome.runtime.lastError);
         else {
           if (result.status === 'on' || result.status === 'paused') {
-            this.status = 'paused';
+            this.status = RecState.PAUSED;
             this.processedCode = result.codeBlocks || [];
           } else {
-            this.status = 'off';
+            this.status = RecState.OFF;
             this.processedCode = [];
           }
           chrome.storage.local.set({ status: this.status, codeBlocks: this.processedCode }, () => {
@@ -40,7 +41,7 @@ export default class Model {
    */
   reset(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.status = 'off';
+      this.status = RecState.OFF;
       this.processedCode = [];
       chrome.storage.local.set({ status: this.status, codeBlocks: this.processedCode }, () => {
         if (chrome.runtime.lastError) reject(chrome.runtime.lastError);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Cypress Recorder",
   "short_name": "Cypress Rec",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Records a user session and generates cypress code for automation and testing purposes.",
   "manifest_version": 2,
   "permissions": [

--- a/src/popup/components/App.tsx
+++ b/src/popup/components/App.tsx
@@ -3,32 +3,32 @@ import Header from './Header';
 import Info from './Info';
 import Footer from './Footer';
 import Body from './Body';
-import { RecState, Block, ActionWithPayload } from '../../types';
-import { ControlAction } from '../../constants';
+import { Block, ActionWithPayload } from '../../types';
+import { ControlAction, RecState } from '../../constants';
 import '../../assets/styles/styles.scss';
 
 export default () => {
-  const [recStatus, setRecStatus] = React.useState<RecState>('off');
+  const [recStatus, setRecStatus] = React.useState<RecState>(RecState.OFF);
   const [codeBlocks, setCodeBlocks] = React.useState<Block[]>([]);
   const [shouldInfoDisplay, setShouldInfoDisplay] = React.useState<boolean>(false);
   const [isValidTab, setIsValidTab] = React.useState<boolean>(true);
 
   const startRecording = (): void => {
-    setRecStatus('on');
+    setRecStatus(RecState.ON);
   };
   const stopRecording = (): void => {
-    setRecStatus('paused');
+    setRecStatus(RecState.PAUSED);
   };
   const resetRecording = (): void => {
-    setRecStatus('off');
+    setRecStatus(RecState.OFF);
     setCodeBlocks([]);
   };
 
   React.useEffect((): void => {
     chrome.storage.local.get(['status', 'codeBlocks'], result => {
       if (result.codeBlocks) setCodeBlocks(result.codeBlocks);
-      if (result.status === 'on') setRecStatus('on');
-      else if (result.status === 'paused') setRecStatus('paused');
+      if (result.status === RecState.ON) setRecStatus(RecState.ON);
+      else if (result.status === RecState.PAUSED) setRecStatus(RecState.PAUSED);
     });
     chrome.tabs.query({ active: true, currentWindow: true }, activeTab => {
       if (activeTab[0].url.startsWith('chrome://')) setIsValidTab(false);

--- a/src/popup/components/Body.tsx
+++ b/src/popup/components/Body.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { RecState, Block } from '../../types';
+import { Block } from '../../types';
+import { RecState } from '../../constants';
 
 import CodeDisplay from './CodeDisplay';
 import LandingBox from './LandingBox';
@@ -20,7 +21,7 @@ export default ({
   moveBlock,
 }: BodyProps) => (
   <div id="body">
-    {recStatus === 'off' && <LandingBox isValidTab={isValidTab} />}
-    {recStatus !== 'off' && <CodeDisplay codeBlocks={codeBlocks} destroyBlock={destroyBlock} moveBlock={moveBlock} />}
+    {recStatus === RecState.OFF && <LandingBox isValidTab={isValidTab} />}
+    {recStatus !== RecState.OFF && <CodeDisplay codeBlocks={codeBlocks} destroyBlock={destroyBlock} moveBlock={moveBlock} />}
   </div>
 );

--- a/src/popup/components/Footer.tsx
+++ b/src/popup/components/Footer.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import ToggleButton from './ToggleButton';
 import ResetButton from './ResetButton';
 import ClipboardButton from './ClipboardButton';
-import { ControlAction } from '../../constants';
+import { ControlAction, RecState } from '../../constants';
 
 export interface FooterProps {
   isValidTab: boolean,
-  recStatus: string,
+  recStatus: RecState,
   handleToggle: (action: ControlAction) => void,
   copyToClipboard: () => Promise<void>,
 }
@@ -19,7 +19,7 @@ export default ({
 } : FooterProps) => (
   <div id="footer">
     <ToggleButton recStatus={recStatus} handleToggle={handleToggle} isValidTab={isValidTab} />
-    {recStatus === 'paused' && <ResetButton handleToggle={handleToggle} />}
-    {recStatus === 'paused' && <ClipboardButton copyToClipboard={copyToClipboard} />}
+    {recStatus === RecState.PAUSED && <ResetButton handleToggle={handleToggle} />}
+    {recStatus === RecState.PAUSED && <ClipboardButton copyToClipboard={copyToClipboard} />}
   </div>
 );

--- a/src/popup/components/ToggleButton.tsx
+++ b/src/popup/components/ToggleButton.tsx
@@ -1,29 +1,37 @@
 import * as React from 'react';
-import { ControlAction } from '../../constants';
+import { ControlAction, RecState } from '../../constants';
 
 export interface ToggleButtonProps {
   isValidTab: boolean,
-  recStatus: string,
+  recStatus: RecState,
   handleToggle: (action: ControlAction) => void,
 }
 
 export default ({ recStatus, handleToggle, isValidTab }: ToggleButtonProps) => {
   const handleClick = (): void => {
     let action: ControlAction;
-    if (recStatus === 'off' || recStatus === 'paused') action = ControlAction.START;
-    else if (recStatus === 'on') action = ControlAction.STOP;
+    if (recStatus === RecState.OFF || recStatus === RecState.PAUSED) action = ControlAction.START;
+    else if (recStatus === RecState.ON) action = ControlAction.STOP;
     handleToggle(action);
   };
 
-  const buttonClass: string = (!isValidTab && (recStatus === 'off' || recStatus === 'paused')) ? 'disabled-button' : 'button';
+  const buttonClass: string = (!isValidTab && (recStatus === RecState.OFF || recStatus === RecState.PAUSED))
+    ? 'disabled-button'
+    : 'button';
 
   return (
     <div id="toggle-wrap">
-      <button type="button" id="toggle" className={buttonClass} onClick={handleClick} disabled={!isValidTab && (recStatus === 'off' || recStatus === 'paused')}>
-        {(recStatus === 'off' || recStatus === 'paused') && !isValidTab && 'Invalid Tab'}
-        {recStatus === 'off' && isValidTab && 'Start Recording'}
-        {recStatus === 'paused' && isValidTab && 'Resume'}
-        {recStatus === 'on' && 'Stop Recording'}
+      <button
+        type="button"
+        id="toggle"
+        className={buttonClass}
+        onClick={handleClick}
+        disabled={!isValidTab && (recStatus === RecState.OFF || recStatus === RecState.PAUSED)}
+      >
+        {(recStatus === RecState.OFF || recStatus === RecState.PAUSED) && !isValidTab && 'Invalid Tab'}
+        {recStatus === RecState.OFF && isValidTab && 'Start Recording'}
+        {recStatus === RecState.PAUSED && isValidTab && 'Resume'}
+        {recStatus === RecState.ON && 'Stop Recording'}
       </button>
     </div>
   );

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,10 +1,5 @@
 import { ControlAction } from '../constants';
 
-export type RecState =
-  | 'off'
-  | 'on'
-  | 'paused';
-
 export interface ParsedEvent {
   selector: string,
   action: string,


### PR DESCRIPTION
- Update to Node 12.16.1, NPM 6.13.4 (latest LTS). Updated dependencies
- ControlAction is now an enum of ints instead of strings--there was no reason to use strings, ints are preferred for performance and maintainability reasons
- Updated RecState to be enum instead of type. Updated corresponding files, including tests.