### PR TITLE
Enable cy.rightclick capture, and mouse coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "npx tsc --noEmit && npx parcel ./src/popup/index.html ./src/background/background.ts ./src/content-scripts/eventRecorder.ts",
-    "build": "npx tsc --noEmit && npx parcel build ./src/popup/index.html ./src/background/background.ts ./src/content-scripts/eventRecorder.ts",
+    "build": "npx tsc --noEmit && npx parcel build ./src/popup/index.html ./src/background/background.ts ./src/content-scripts/eventRecorder.ts && cp ./src/manifest.json ./dist/ && cp ./src/assets/images/* ./dist",
     "test": "jest --verbose",
     "clean": "rm -rf dist .cache && mkdir dist && cp ./src/manifest.json dist && cp -r ./src/assets/images/. dist",
     "tsc": "npx tsc --noEmit",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,6 +4,7 @@ export enum EventType {
   DBLCLICK = 'dblclick',
   KEYDOWN = 'keydown',
   SUBMIT = 'submit',
+  RCLICK = 'contextmenu',
 }
 
 export enum ControlAction {

--- a/src/content-scripts/eventRecorder.ts
+++ b/src/content-scripts/eventRecorder.ts
@@ -20,11 +20,13 @@ function parseEvent(event: Event): ParsedEvent {
   else if ((event.target as Element).hasAttribute('data-test')) selector = `[data-test=${(event.target as Element).getAttribute('data-test')}]`;
   else if ((event.target as Element).hasAttribute('data-testid')) selector = `[data-testid=${(event.target as Element).getAttribute('data-testid')}]`;
   else selector = finder(event.target as Element);
+  const mouseEvent = (event as MouseEvent);
   const parsedEvent: ParsedEvent = {
     selector,
     action: event.type,
     tag: (event.target as Element).tagName,
     value: (event.target as HTMLInputElement).value,
+    location: { x: mouseEvent.offsetX, y: mouseEvent.offsetY},
   };
   if ((event.target as HTMLAnchorElement).hasAttribute('href')) parsedEvent.href = (event.target as HTMLAnchorElement).href;
   if ((event.target as Element).hasAttribute('id')) parsedEvent.id = (event.target as Element).id;

--- a/src/helpers/codeGenerator.ts
+++ b/src/helpers/codeGenerator.ts
@@ -13,7 +13,11 @@ import { EventType } from '../constants';
  */
 
 function handleClick(event: ParsedEvent): string {
-  return `cy.get('${event.selector}').click();`;
+  return `cy.get('${event.selector}').click(${event.location.x}, ${event.location.y});`;
+}
+
+function handleRClick(event: ParsedEvent): string {
+  return `cy.get('${event.selector}').rightclick(${event.location.x}, ${event.location.y});`;
 }
 
 function handleKeydown(event: ParsedEvent): string | null {
@@ -41,7 +45,7 @@ function handleChange(event: ParsedEvent): string {
 }
 
 function handleDoubleclick(event: ParsedEvent): string {
-  return `cy.get('${event.selector}').dblclick();`;
+  return `cy.get('${event.selector}').dblclick(${event.location.x}, ${event.location.y});`;
 }
 
 function handleSubmit(event: ParsedEvent): string {
@@ -58,6 +62,8 @@ export default {
     switch (event.action) {
       case EventType.CLICK:
         return handleClick(event);
+        case EventType.RCLICK:
+          return handleRClick(event);
       case EventType.KEYDOWN:
         return handleKeydown(event);
       case EventType.CHANGE:

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -5,6 +5,7 @@ export interface ParsedEvent {
   action: string,
   tag: string,
   value: string,
+  location?: { x: any, y: any},
   id?: string,
   key?: string,
   href?: string,


### PR DESCRIPTION
- Added the contextmenu capturing
  - Follows same format as standard clicks, I think RCLICK is a short and sweet name, but open to changing
- Enabled capturing of mouse position relative to the click element
  - https://docs.cypress.io/api/commands/click.html#Arguments

- I was running into issues trying to load the unpacked extension because it didn't copy that stuff for me
